### PR TITLE
Applying logic to group objects within the output file when the 'split' attribute is set to true.

### DIFF
--- a/fs-route-type.config.example.js
+++ b/fs-route-type.config.example.js
@@ -8,8 +8,9 @@ module.exports = {
         './app/**/(page|route).(tsx|ts|js|jsx)'
     ],
     output: {
-        mode: 'type',
+        mode: 'object',
         path: './out/types/routes.ts',
-        name: 'Route'
+        name: 'Route',
+        split: false,
     }
 };

--- a/src/config/config.zod.ts
+++ b/src/config/config.zod.ts
@@ -25,6 +25,7 @@ export const ConfigSchema = z.object({
          * Name of output type or object
          */
         name: z.string().default('Route'),
+        split: z.boolean().optional().default(false),
     }).and(z.discriminatedUnion('mode', [
         z.object({
             /**

--- a/src/templates/object.ts
+++ b/src/templates/object.ts
@@ -2,12 +2,53 @@ import { Config } from '@/config';
 import { camelCase, pascalCase, constantCase, snakeCase, paramCase } from 'change-case';
 
 type ObjectTemplateConfig = Extract<Config['output'], { mode: 'object' }>;
+type GroupedPaths = Record<string, string[]>;
+
+function createKey(config: ObjectTemplateConfig, path:string, groupName?: string) {
+    if (groupName) {
+        const regex = new RegExp(`^/${groupName}`);
+        const temp = path.replace(regex, '');
+        return changeCase(temp === '' ? `/${config.rootName}` : temp, config.case);
+    } else {
+        return changeCase(path === '/' ? `/${config.rootName}` : path, config.case);
+    }
+}
+
+function createObject(config: ObjectTemplateConfig, paths: string[], groupName?: string) {
+    return `export const ${changeCase(`/${groupName}`, 'pascal')}${config.name} = {
+    ${paths.map(path => `${createKey(config, path, groupName)}: '${path}'`).join(',\n    ')},
+} as const;`;
+}
+
+const groupingPaths = (paths: string[]): GroupedPaths => {
+    const groupedPaths: GroupedPaths = {};
+
+    for (const path of paths) {
+        if (path === '/') {
+            groupedPaths[''] = ['/'];
+            continue;
+        }
+
+        const pathElements = path.split('/');
+        const category = pathElements[1];
+
+        if (category) {
+            if (!groupedPaths[category]) {
+                groupedPaths[category] = [];
+            }
+            groupedPaths[category]!.push(path);
+        }
+    }
+
+    return groupedPaths;
+};
 
 export const objectTemplate = (config: ObjectTemplateConfig, paths: string[]) => {
-    return `export const ${config.name} = {
-    ${paths.map(path => `${changeCase(path === '/' ? `/${config.rootName}` : path, config.case)}: '${path}'`).join(',\n    ')},
-} as const;
-`;
+    if (config.split) {
+        const groupedPaths = groupingPaths(paths);
+        return Object.keys(groupedPaths).map((groupName) => createObject(config, groupedPaths[groupName]!, groupName)).join('\n\n');
+    }
+    return createObject(config, paths);
 };
 
 const changeCase = (path: string, caseStyle: ObjectTemplateConfig['case']): string => {


### PR DESCRIPTION
### split: false
```tsx
/**
 * This file is generated by fs-routing-type on 8/27/2023, 12:48:54 AM.
 * Do not edit this file directly, it may be overwritten.
 */

export const Route = {
    ROOT: '/',
    TEST: '/test',
    TEST_TEST_ENG: '/test/test/eng',
    TEST_MATH: '/test/math',
    TEST_FOO: '/test/foo',
    TEST_FOO_BAR: '/test/foo/bar',
} as const;
```

### split: true
```tsx
/**
 * This file is generated by fs-routing-type on 8/27/2023, 12:49:50 AM.
 * Do not edit this file directly, it may be overwritten.
 */

export const Route = {
    ROOT: '/',
} as const;

export const TestRoute = {
    ROOT: '/test',
    TEST_ENG: '/test/test/eng',
    MATH: '/test/math',
    FOO: '/test/foo',
    FOO_BAR: '/test/foo/bar',
} as const;
```

For now, the above logic has been applied only when mode is set to 'object'. In the next task, we'll be addressing the scenario when mode is set to 'type'.